### PR TITLE
fix: unbound value & onRenderValue

### DIFF
--- a/src/JsonEditorPlugin.ts
+++ b/src/JsonEditorPlugin.ts
@@ -70,6 +70,7 @@ export type {
   EditValueSelection,
   createJSONEditor,
 };
+export {renderValue, renderJSONSchemaEnum} from 'vanilla-jsoneditor';
 
 export const JsonEditorPlugin: Plugin<Params> = {
   install(app, params = {}) {

--- a/src/components/JsonEditor.vue
+++ b/src/components/JsonEditor.vue
@@ -660,7 +660,7 @@ export default defineComponent({
 
     const updateProps = async () => {
       const props = await makeEditorProps();
-      editor.value.updateProps(props);
+      editor.value?.updateProps(props);
     };
 
     const updateContent = () => {
@@ -669,7 +669,7 @@ export default defineComponent({
         return;
       }
       blockChange.value = true;
-      editor.value.update(getContent());
+      editor.value?.update(getContent());
     };
 
     const destroyView = () => {


### PR DESCRIPTION
### - unbound value
when value is sent in the component via `v-bind:json` or `:modelValue` - `editor.value` was expected to exist before initView completed

added null-coalescing operator where it was missing

### - onRenderValue
in order to have a fallback render - `renderValue` from `svelte-jsoneditor` should be used
but using a direct  `import {renderValue} from 'vanilla-jsoneditor';` - does not work, it fails on call of some Node property (not sure why, might be some internals need to init properly 🤷‍♂️)

fixed by using renderValue re-exported by this package
`export {renderValue, renderJSONSchemaEnum} from 'vanilla-jsoneditor';`

[example](https://pastebin.com/kH5L9Dcn) for image preview