### PR TITLE
Fixed full-width button

### DIFF
--- a/src/components/JsonEditor.vue
+++ b/src/components/JsonEditor.vue
@@ -471,7 +471,7 @@ export default defineComponent({
       const {setFullWidthButtonStyle} = await import('./styles-handler');
       await setFullWidthButtonStyle();
 
-      const oldButton = getElement('.jse-full-width');
+      const oldButton = getElement(container.value, '.jse-full-width');
 
       const pluginOptionFlag = pluginOptions?.fullWidthButton !== undefined ? pluginOptions?.fullWidthButton : true;
 
@@ -483,11 +483,14 @@ export default defineComponent({
         removeFullWidthButton();
       }
 
-      const menu = getElement('.jse-menu');
+      const menu = getElement(container.value, '.jse-menu');
       const menuSvelteClass = Array.from(menu.classList).find((menuClass) => menuClass.startsWith('svelte-'));
 
       fullWidthButton.value = createElement('button') as HTMLButtonElement;
       fullWidthButton.value.classList.add('jse-full-width');
+      if (max.value) {
+        fullWidthButton.value.classList.add('jse-full-width--active');
+      }
       fullWidthButton.value.classList.add('jse-button');
       fullWidthButton.value.classList.add(menuSvelteClass);
 
@@ -505,6 +508,7 @@ export default defineComponent({
         fullWidthButton.value?.classList.add('jse-full-width--active');
       } else {
         fullWidthButton.value?.classList.remove('jse-full-width--active');
+        fullWidthButton.value?.blur();
       }
     };
 

--- a/src/components/full-width-button-handler.ts
+++ b/src/components/full-width-button-handler.ts
@@ -1,3 +1,3 @@
-export const getElement = (selector: string): HTMLElement | null => window?.document.querySelector(selector);
+export const getElement = (parentEl: HTMLElement, selector: string): HTMLElement | null => parentEl.querySelector(selector);
 
 export const createElement = (tagName: string): HTMLElement => window?.document.createElement(tagName);


### PR DESCRIPTION
**Fixed the following issues:**
1. The full-width button still focused after exiting full-width mode;
2. When more than one json-editor component exists, the full-width button would only be added to the first component;
3. Switching modes in full-width state would cause the full-width button to lose its active style.